### PR TITLE
Networking

### DIFF
--- a/Sudoku/Sudoku.xcodeproj/project.pbxproj
+++ b/Sudoku/Sudoku.xcodeproj/project.pbxproj
@@ -12,6 +12,12 @@
 		F60B9D722B0BA0520036AA1B /* UIBarButtonItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = F60B9D712B0BA0520036AA1B /* UIBarButtonItem.swift */; };
 		F60B9D742B0C9D740036AA1B /* AbilityButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = F60B9D732B0C9D740036AA1B /* AbilityButton.swift */; };
 		F60B9D762B0CA85A0036AA1B /* NumberButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = F60B9D752B0CA85A0036AA1B /* NumberButton.swift */; };
+		F60B9D792B0DD1EB0036AA1B /* Networking.swift in Sources */ = {isa = PBXBuildFile; fileRef = F60B9D782B0DD1EB0036AA1B /* Networking.swift */; };
+		F60B9D7B2B0DD22E0036AA1B /* NetworkingError.swift in Sources */ = {isa = PBXBuildFile; fileRef = F60B9D7A2B0DD22E0036AA1B /* NetworkingError.swift */; };
+		F60B9D7E2B0DD2670036AA1B /* SudokuDataDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = F60B9D7D2B0DD2670036AA1B /* SudokuDataDTO.swift */; };
+		F60B9D802B0DD2800036AA1B /* SudokuBoardDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = F60B9D7F2B0DD2800036AA1B /* SudokuBoardDTO.swift */; };
+		F60B9D822B0DD2B00036AA1B /* SudokuData.swift in Sources */ = {isa = PBXBuildFile; fileRef = F60B9D812B0DD2B00036AA1B /* SudokuData.swift */; };
+		F60B9D842B0DD3030036AA1B /* GameDifficulty.swift in Sources */ = {isa = PBXBuildFile; fileRef = F60B9D832B0DD3030036AA1B /* GameDifficulty.swift */; };
 		F60BB9412B031BD9005137FE /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F60BB9402B031BD9005137FE /* AppDelegate.swift */; };
 		F60BB9432B031BD9005137FE /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F60BB9422B031BD9005137FE /* SceneDelegate.swift */; };
 		F60BB9452B031BD9005137FE /* HomeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F60BB9442B031BD9005137FE /* HomeViewController.swift */; };
@@ -27,6 +33,12 @@
 		F60B9D712B0BA0520036AA1B /* UIBarButtonItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIBarButtonItem.swift; sourceTree = "<group>"; };
 		F60B9D732B0C9D740036AA1B /* AbilityButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AbilityButton.swift; sourceTree = "<group>"; };
 		F60B9D752B0CA85A0036AA1B /* NumberButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NumberButton.swift; sourceTree = "<group>"; };
+		F60B9D782B0DD1EB0036AA1B /* Networking.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Networking.swift; sourceTree = "<group>"; };
+		F60B9D7A2B0DD22E0036AA1B /* NetworkingError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkingError.swift; sourceTree = "<group>"; };
+		F60B9D7D2B0DD2670036AA1B /* SudokuDataDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SudokuDataDTO.swift; sourceTree = "<group>"; };
+		F60B9D7F2B0DD2800036AA1B /* SudokuBoardDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SudokuBoardDTO.swift; sourceTree = "<group>"; };
+		F60B9D812B0DD2B00036AA1B /* SudokuData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SudokuData.swift; sourceTree = "<group>"; };
+		F60B9D832B0DD3030036AA1B /* GameDifficulty.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameDifficulty.swift; sourceTree = "<group>"; };
 		F60BB93D2B031BD9005137FE /* Sudoku.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Sudoku.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		F60BB9402B031BD9005137FE /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		F60BB9422B031BD9005137FE /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -49,6 +61,27 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		F60B9D772B0DD1BD0036AA1B /* Model */ = {
+			isa = PBXGroup;
+			children = (
+				F60B9D7C2B0DD2460036AA1B /* DTO */,
+				F60B9D782B0DD1EB0036AA1B /* Networking.swift */,
+				F60B9D7A2B0DD22E0036AA1B /* NetworkingError.swift */,
+				F60B9D832B0DD3030036AA1B /* GameDifficulty.swift */,
+			);
+			path = Model;
+			sourceTree = "<group>";
+		};
+		F60B9D7C2B0DD2460036AA1B /* DTO */ = {
+			isa = PBXGroup;
+			children = (
+				F60B9D7D2B0DD2670036AA1B /* SudokuDataDTO.swift */,
+				F60B9D7F2B0DD2800036AA1B /* SudokuBoardDTO.swift */,
+				F60B9D812B0DD2B00036AA1B /* SudokuData.swift */,
+			);
+			path = DTO;
+			sourceTree = "<group>";
+		};
 		F60BB9342B031BD9005137FE = {
 			isa = PBXGroup;
 			children = (
@@ -68,6 +101,7 @@
 		F60BB93F2B031BD9005137FE /* Sudoku */ = {
 			isa = PBXGroup;
 			children = (
+				F60B9D772B0DD1BD0036AA1B /* Model */,
 				F60BB9572B0321C4005137FE /* Extension */,
 				F60BB9542B031F22005137FE /* View */,
 				F60BB9402B031BD9005137FE /* AppDelegate.swift */,
@@ -172,14 +206,20 @@
 			buildActionMask = 2147483647;
 			files = (
 				F60B9D702B0B04CC0036AA1B /* GameViewController.swift in Sources */,
+				F60B9D792B0DD1EB0036AA1B /* Networking.swift in Sources */,
 				F60BB9452B031BD9005137FE /* HomeViewController.swift in Sources */,
 				F60B9D6E2B0AF5F70036AA1B /* UIColor.swift in Sources */,
+				F60B9D7E2B0DD2670036AA1B /* SudokuDataDTO.swift in Sources */,
 				F60BB9592B0321D6005137FE /* TimeInterval.swift in Sources */,
 				F60B9D742B0C9D740036AA1B /* AbilityButton.swift in Sources */,
 				F60BB9562B031F34005137FE /* GameButton.swift in Sources */,
 				F60BB9412B031BD9005137FE /* AppDelegate.swift in Sources */,
+				F60B9D822B0DD2B00036AA1B /* SudokuData.swift in Sources */,
+				F60B9D802B0DD2800036AA1B /* SudokuBoardDTO.swift in Sources */,
 				F60B9D722B0BA0520036AA1B /* UIBarButtonItem.swift in Sources */,
+				F60B9D842B0DD3030036AA1B /* GameDifficulty.swift in Sources */,
 				F60B9D762B0CA85A0036AA1B /* NumberButton.swift in Sources */,
+				F60B9D7B2B0DD22E0036AA1B /* NetworkingError.swift in Sources */,
 				F60BB9432B031BD9005137FE /* SceneDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Sudoku/Sudoku/Model/DTO/SudokuBoardDTO.swift
+++ b/Sudoku/Sudoku/Model/DTO/SudokuBoardDTO.swift
@@ -1,0 +1,20 @@
+//
+//  SudokuBoardDTO.swift
+//  Sudoku
+//
+//  Created by 박재우 on 11/22/23.
+//
+
+import Foundation
+
+struct SudokuBoardDTO: Decodable {
+    let data: [SudokuData]
+    let results: Int
+    let message: String
+
+    enum CodingKeys: String, CodingKey {
+        case data = "grids"
+        case results
+        case message
+    }
+}

--- a/Sudoku/Sudoku/Model/DTO/SudokuData.swift
+++ b/Sudoku/Sudoku/Model/DTO/SudokuData.swift
@@ -1,0 +1,20 @@
+//
+//  SudokuData.swift
+//  Sudoku
+//
+//  Created by 박재우 on 11/22/23.
+//
+
+import Foundation
+
+struct SudokuData: Decodable {
+    let problem: [[Int]]
+    let solution: [[Int]]
+    let difficulty: GameDifficulty
+
+    enum CodingKeys: String, CodingKey {
+        case problem = "value"
+        case solution
+        case difficulty
+    }
+}

--- a/Sudoku/Sudoku/Model/DTO/SudokuDataDTO.swift
+++ b/Sudoku/Sudoku/Model/DTO/SudokuDataDTO.swift
@@ -1,0 +1,16 @@
+//
+//  SudokuDataDTO.swift
+//  Sudoku
+//
+//  Created by 박재우 on 11/22/23.
+//
+
+import Foundation
+
+struct SudokuDataDTO: Decodable {
+    let newboard: SudokuBoardDTO
+
+    func fetch() -> SudokuData? {
+        return newboard.data.first
+    }
+}

--- a/Sudoku/Sudoku/Model/GameDifficulty.swift
+++ b/Sudoku/Sudoku/Model/GameDifficulty.swift
@@ -1,0 +1,14 @@
+//
+//  GameDifficulty.swift
+//  Sudoku
+//
+//  Created by 박재우 on 11/22/23.
+//
+
+import Foundation
+
+enum GameDifficulty: String, Decodable {
+    case easy = "쉬움"
+    case medium = "보통"
+    case hard = "어려움"
+}

--- a/Sudoku/Sudoku/Model/Networking.swift
+++ b/Sudoku/Sudoku/Model/Networking.swift
@@ -1,0 +1,48 @@
+//
+//  Networking.swift
+//  Sudoku
+//
+//  Created by 박재우 on 11/22/23.
+//
+
+import Foundation
+
+struct Networking {
+    private let endpoint = "https://sudoku-api.vercel.app/api/dosuku"
+
+    func loadData(complition: @escaping (Result<SudokuData?, NetworkError>) -> Void) {
+        guard let url = URL(string: endpoint) else {
+            complition(.failure(.invalidURL))
+            return
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+
+        URLSession.shared.dataTask(with: request) { data, response, error in
+            if error != nil {
+                complition(.failure(.transportError))
+            }
+
+            guard let data else {
+                complition(.failure(.missingData))
+                return
+            }
+
+            guard let response = response as? HTTPURLResponse,
+                  (200...299) ~= response.statusCode
+            else {
+                complition(.failure(.serverError))
+                return
+            }
+
+            guard let decodedData = try? JSONDecoder().decode(SudokuDataDTO.self, from: data) else {
+                complition(.failure(.decodingError))
+                return
+            }
+
+            complition(.success(decodedData.fetch()))
+        }
+        .resume()
+    }
+}

--- a/Sudoku/Sudoku/Model/NetworkingError.swift
+++ b/Sudoku/Sudoku/Model/NetworkingError.swift
@@ -1,0 +1,16 @@
+//
+//  NetworkingError.swift
+//  Sudoku
+//
+//  Created by 박재우 on 11/22/23.
+//
+
+import Foundation
+
+enum NetworkError: Error {
+    case invalidURL
+    case transportError
+    case serverError
+    case missingData
+    case decodingError
+}


### PR DESCRIPTION
## Networking 관련 코드 추가
1. Sudoku API 관련 DTO, 데이터 타입 추가
2. API 통신을 위해 Networking 추가

---
### 사이트에서 제공되는 `Error` 상세 내용이 없어서 `NetworkingError`로 구현
```swift
enum NetworkError: Error {
    case invalidURL
    case transportError
    case serverError
    case missingData
    case decodingError
}
```
### SudokuData 변환
JSON 타입의 데이터를 DTO로 변환하고 최종적으로 코드에서 원하는 `SudokuData`로 변환
```swift
struct SudokuDataDTO: Decodable {
    let newboard: SudokuBoardDTO

    func fetch() -> SudokuData? {
        return newboard.data.first
    }
}

struct Networking {
    func loadData(complition: @escaping (Result<SudokuData?, NetworkError>) -> Void) {
        // ...
        complition(.success(decodedData.fetch()))
    }
}
```