### PR TITLE
Information views

### DIFF
--- a/Sudoku/Sudoku.xcodeproj/project.pbxproj
+++ b/Sudoku/Sudoku.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		F60B9D802B0DD2800036AA1B /* SudokuBoardDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = F60B9D7F2B0DD2800036AA1B /* SudokuBoardDTO.swift */; };
 		F60B9D822B0DD2B00036AA1B /* SudokuData.swift in Sources */ = {isa = PBXBuildFile; fileRef = F60B9D812B0DD2B00036AA1B /* SudokuData.swift */; };
 		F60B9D842B0DD3030036AA1B /* GameDifficulty.swift in Sources */ = {isa = PBXBuildFile; fileRef = F60B9D832B0DD3030036AA1B /* GameDifficulty.swift */; };
+		F60B9D862B0DEAED0036AA1B /* InformationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F60B9D852B0DEAED0036AA1B /* InformationView.swift */; };
 		F60BB9412B031BD9005137FE /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F60BB9402B031BD9005137FE /* AppDelegate.swift */; };
 		F60BB9432B031BD9005137FE /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F60BB9422B031BD9005137FE /* SceneDelegate.swift */; };
 		F60BB9452B031BD9005137FE /* HomeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F60BB9442B031BD9005137FE /* HomeViewController.swift */; };
@@ -39,6 +40,7 @@
 		F60B9D7F2B0DD2800036AA1B /* SudokuBoardDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SudokuBoardDTO.swift; sourceTree = "<group>"; };
 		F60B9D812B0DD2B00036AA1B /* SudokuData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SudokuData.swift; sourceTree = "<group>"; };
 		F60B9D832B0DD3030036AA1B /* GameDifficulty.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameDifficulty.swift; sourceTree = "<group>"; };
+		F60B9D852B0DEAED0036AA1B /* InformationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InformationView.swift; sourceTree = "<group>"; };
 		F60BB93D2B031BD9005137FE /* Sudoku.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Sudoku.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		F60BB9402B031BD9005137FE /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		F60BB9422B031BD9005137FE /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -121,6 +123,7 @@
 				F60BB9552B031F34005137FE /* GameButton.swift */,
 				F60B9D732B0C9D740036AA1B /* AbilityButton.swift */,
 				F60B9D752B0CA85A0036AA1B /* NumberButton.swift */,
+				F60B9D852B0DEAED0036AA1B /* InformationView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -219,6 +222,7 @@
 				F60B9D722B0BA0520036AA1B /* UIBarButtonItem.swift in Sources */,
 				F60B9D842B0DD3030036AA1B /* GameDifficulty.swift in Sources */,
 				F60B9D762B0CA85A0036AA1B /* NumberButton.swift in Sources */,
+				F60B9D862B0DEAED0036AA1B /* InformationView.swift in Sources */,
 				F60B9D7B2B0DD22E0036AA1B /* NetworkingError.swift in Sources */,
 				F60BB9432B031BD9005137FE /* SceneDelegate.swift in Sources */,
 			);

--- a/Sudoku/Sudoku/GameViewController.swift
+++ b/Sudoku/Sudoku/GameViewController.swift
@@ -38,15 +38,16 @@ class GameViewController: UIViewController {
         setUI()
         setLayout()
 
-        InformationView.Information.allCases.forEach { information in
-            let informationView = InformationView(type: information)
+        let difficultyView = InformationView()
+        difficultyView.updateContent(by: .difficulty(content: "쉬움"))
+        let mistakeView = InformationView()
+        mistakeView.updateContent(by: .mistake(content: 0))
+        let timerView = InformationView()
+        timerView.updateContent(by: .timer(content: 3))
 
-            switch information {
-            case .difficulty: informationView.updateContent("쉬움")
-            case .mistake, .timer: informationView.updateContent(0)
-            }
-            informationStackView.addArrangedSubview(informationView)
-        }
+        informationStackView.addArrangedSubview(difficultyView)
+        informationStackView.addArrangedSubview(mistakeView)
+        informationStackView.addArrangedSubview(timerView)
 
         AbilityButton.Ability.allCases.forEach { ability in
             let abilityButton = AbilityButton(of: ability)

--- a/Sudoku/Sudoku/GameViewController.swift
+++ b/Sudoku/Sudoku/GameViewController.swift
@@ -13,6 +13,12 @@ class GameViewController: UIViewController {
 
     private var isTimerRun: Bool = true
 
+    private var informationStackView = {
+        let stackView = UIStackView()
+        stackView.distribution = .equalCentering
+        return stackView
+    }()
+
     private var abilityStackView = {
         let stackView = UIStackView()
         stackView.distribution = .equalCentering
@@ -31,6 +37,16 @@ class GameViewController: UIViewController {
 
         setUI()
         setLayout()
+
+        InformationView.Information.allCases.forEach { information in
+            let informationView = InformationView(type: information)
+
+            switch information {
+            case .difficulty: informationView.updateContent("쉬움")
+            case .mistake, .timer: informationView.updateContent(0)
+            }
+            informationStackView.addArrangedSubview(informationView)
+        }
 
         AbilityButton.Ability.allCases.forEach { ability in
             let abilityButton = AbilityButton(of: ability)
@@ -56,13 +72,19 @@ class GameViewController: UIViewController {
     }
 
     private func setLayout() {
+        view.addSubview(informationStackView)
         view.addSubview(abilityStackView)
         view.addSubview(numberStackView)
 
+        informationStackView.translatesAutoresizingMaskIntoConstraints = false
         abilityStackView.translatesAutoresizingMaskIntoConstraints = false
         numberStackView.translatesAutoresizingMaskIntoConstraints = false
 
         NSLayoutConstraint.activate([
+            informationStackView.widthAnchor.constraint(equalTo: view.widthAnchor, multiplier: 0.8),
+            informationStackView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 30),
+            informationStackView.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+
             abilityStackView.widthAnchor.constraint(equalTo: view.widthAnchor, multiplier: 0.9),
             abilityStackView.heightAnchor.constraint(equalToConstant: 60),
             abilityStackView.bottomAnchor.constraint(equalTo: numberStackView.topAnchor, constant: -30),

--- a/Sudoku/Sudoku/View/InformationView.swift
+++ b/Sudoku/Sudoku/View/InformationView.swift
@@ -1,0 +1,102 @@
+//
+//  InformationView.swift
+//  Sudoku
+//
+//  Created by 박재우 on 11/22/23.
+//
+
+import UIKit
+
+class InformationView: UIView {
+    private let titleLabel = {
+        let imageViewLabel = UILabel()
+        imageViewLabel.font = .systemFont(ofSize: 18, weight: .bold)
+        imageViewLabel.textColor = .brightMainColor1
+        imageViewLabel.textAlignment = .center
+        return imageViewLabel
+    }()
+
+    private let contentLabel = {
+        let imageViewLabel = UILabel()
+        imageViewLabel.font = .systemFont(ofSize: 13, weight: .bold)
+        imageViewLabel.textColor = .brightMainColor1
+        imageViewLabel.textAlignment = .center
+        return imageViewLabel
+    }()
+
+    private let type: Information
+
+    init(type: Information) {
+        self.type = type
+
+        super.init(frame: .zero)
+
+        setUI()
+        setLayout()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    private func setUI() {
+        titleLabel.text = type.title
+    }
+
+    private func setLayout() {
+        addSubview(titleLabel)
+        addSubview(contentLabel)
+
+        titleLabel.translatesAutoresizingMaskIntoConstraints = false
+        contentLabel.translatesAutoresizingMaskIntoConstraints = false
+
+        NSLayoutConstraint.activate([
+            titleLabel.topAnchor.constraint(equalTo: self.topAnchor),
+            titleLabel.leadingAnchor.constraint(equalTo: self.leadingAnchor),
+            titleLabel.trailingAnchor.constraint(equalTo: self.trailingAnchor),
+            titleLabel.bottomAnchor.constraint(equalTo: contentLabel.topAnchor, constant: -8),
+
+            contentLabel.leadingAnchor.constraint(equalTo: self.leadingAnchor),
+            contentLabel.trailingAnchor.constraint(equalTo: self.trailingAnchor),
+            contentLabel.bottomAnchor.constraint(equalTo: self.bottomAnchor),
+        ])
+    }
+
+    func updateContent(_ content: Any) {
+        switch type {
+        case .difficulty:
+            contentLabel.text = "\(content)"
+        case .mistake:
+            contentLabel.text = "\(content) / 3"
+        case .timer:
+            contentLabel.text = updateTime(content as! Int)
+        }
+    }
+
+    private func updateTime(_ time: Int) -> String {
+        let minutes = time / 60
+        let seconds = time % 60
+
+        return String(format: "%02d:%02d", minutes, seconds)
+    }
+
+}
+
+extension InformationView {
+    enum Information: CaseIterable {
+        case difficulty
+        case mistake
+        case timer
+
+        fileprivate var title: String {
+            switch self {
+            case .difficulty:
+                return "난이도"
+            case .mistake:
+                return "실수"
+            case .timer:
+                return "시간"
+            }
+        }
+    }
+}

--- a/Sudoku/Sudoku/View/InformationView.swift
+++ b/Sudoku/Sudoku/View/InformationView.swift
@@ -24,23 +24,14 @@ class InformationView: UIView {
         return imageViewLabel
     }()
 
-    private let type: Information
+    override init(frame: CGRect) {
+        super.init(frame: frame)
 
-    init(type: Information) {
-        self.type = type
-
-        super.init(frame: .zero)
-
-        setUI()
         setLayout()
     }
     
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
-    }
-
-    private func setUI() {
-        titleLabel.text = type.title
     }
 
     private func setLayout() {
@@ -62,14 +53,15 @@ class InformationView: UIView {
         ])
     }
 
-    func updateContent(_ content: Any) {
+    func updateContent(by type: Information) {
+        titleLabel.text = type.title
         switch type {
-        case .difficulty:
-            contentLabel.text = "\(content)"
-        case .mistake:
+        case .difficulty(let content):
+            contentLabel.text = content
+        case .mistake(let content):
             contentLabel.text = "\(content) / 3"
-        case .timer:
-            contentLabel.text = updateTime(content as! Int)
+        case .timer(let content):
+            contentLabel.text = updateTime(content)
         }
     }
 
@@ -79,14 +71,13 @@ class InformationView: UIView {
 
         return String(format: "%02d:%02d", minutes, seconds)
     }
-
 }
 
 extension InformationView {
-    enum Information: CaseIterable {
-        case difficulty
-        case mistake
-        case timer
+    enum Information {
+        case difficulty(content: String)
+        case mistake(content: Int)
+        case timer(content: Int)
 
         fileprivate var title: String {
             switch self {


### PR DESCRIPTION
## Information Views
난이도, 실수, 시간에 따른 InformationView 생성했어요.
`titleLabel`과 `contentLabel` 존재해요.
`titleLabel`은 타입별 지정된 `title`로 보여줘요.
```swift
extension InformationView {
    enum Information: CaseIterable {
        case difficulty
        case mistake
        case timer

        fileprivate var title: String {
            switch self {
            case .difficulty:
                return "난이도"
            case .mistake:
                return "실수"
            case .timer:
                return "시간"
            }
        }
    }
}
```
### 구성된 InformationViews
<img width="393" alt="스크린샷 2023-11-22 오후 10 21 40" src="https://github.com/ohdair/Sudoku/assets/79438622/a9292453-1b94-40d0-a401-080f8e61385f">

### 🚨 updateContent의 문제 🚨
content로 들어오는 매개변수는 Information 타입별로 고정되어 있습니다. 
- difficulty 라면 String
- mistakse 라면 Int
- timer 라면 Int

아래와 같은 코드로 구성을 했으나 더 나은 방법을 찾고 있습니다.

```swift
func updateContent(_ content: Any) {
    switch type {
    case .difficulty:
        contentLabel.text = "\(content)"
    case .mistake:
        contentLabel.text = "\(content) / 3"
    case .timer:
        contentLabel.text = updateTime(content as! Int)
    }
}

private func updateTime(_ time: Int) -> String {
    let minutes = time / 60
    let seconds = time % 60

    return String(format: "%02d:%02d", minutes, seconds)
}
```

### 📌 updateContent의 해결 방법? 
1. 오버로딩 함수를 이용하여 구성
  ```swift
  func updateContent(_ content: Int)
  func updateContent(_ content: String)
  ```
2. protocol 혹은 generic을 이용한 구성?