### PR TITLE
Sudoku board

### DIFF
--- a/Sudoku/Sudoku.xcodeproj/project.pbxproj
+++ b/Sudoku/Sudoku.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		F60BB9562B031F34005137FE /* GameButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = F60BB9552B031F34005137FE /* GameButton.swift */; };
 		F60BB9592B0321D6005137FE /* TimeInterval.swift in Sources */ = {isa = PBXBuildFile; fileRef = F60BB9582B0321D6005137FE /* TimeInterval.swift */; };
 		F632725F2B13217E00F16FA8 /* CellButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = F632725E2B13217E00F16FA8 /* CellButton.swift */; };
+		F63272612B1429DB00F16FA8 /* SectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F63272602B1429DB00F16FA8 /* SectionView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -54,6 +55,7 @@
 		F60BB9552B031F34005137FE /* GameButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameButton.swift; sourceTree = "<group>"; };
 		F60BB9582B0321D6005137FE /* TimeInterval.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeInterval.swift; sourceTree = "<group>"; };
 		F632725E2B13217E00F16FA8 /* CellButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CellButton.swift; sourceTree = "<group>"; };
+		F63272602B1429DB00F16FA8 /* SectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SectionView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -129,6 +131,7 @@
 				F60B9D752B0CA85A0036AA1B /* NumberButton.swift */,
 				F60B9D852B0DEAED0036AA1B /* InformationView.swift */,
 				F632725E2B13217E00F16FA8 /* CellButton.swift */,
+				F63272602B1429DB00F16FA8 /* SectionView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -226,6 +229,7 @@
 				F60B9D822B0DD2B00036AA1B /* SudokuData.swift in Sources */,
 				F60B9D802B0DD2800036AA1B /* SudokuBoardDTO.swift in Sources */,
 				F60B9D722B0BA0520036AA1B /* UIBarButtonItem.swift in Sources */,
+				F63272612B1429DB00F16FA8 /* SectionView.swift in Sources */,
 				F60B9D842B0DD3030036AA1B /* GameDifficulty.swift in Sources */,
 				F632725F2B13217E00F16FA8 /* CellButton.swift in Sources */,
 				F60B9D762B0CA85A0036AA1B /* NumberButton.swift in Sources */,

--- a/Sudoku/Sudoku.xcodeproj/project.pbxproj
+++ b/Sudoku/Sudoku.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		F60BB94D2B031BDA005137FE /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = F60BB94B2B031BDA005137FE /* LaunchScreen.storyboard */; };
 		F60BB9562B031F34005137FE /* GameButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = F60BB9552B031F34005137FE /* GameButton.swift */; };
 		F60BB9592B0321D6005137FE /* TimeInterval.swift in Sources */ = {isa = PBXBuildFile; fileRef = F60BB9582B0321D6005137FE /* TimeInterval.swift */; };
+		F632725F2B13217E00F16FA8 /* CellButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = F632725E2B13217E00F16FA8 /* CellButton.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -52,6 +53,7 @@
 		F60BB94E2B031BDA005137FE /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		F60BB9552B031F34005137FE /* GameButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameButton.swift; sourceTree = "<group>"; };
 		F60BB9582B0321D6005137FE /* TimeInterval.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeInterval.swift; sourceTree = "<group>"; };
+		F632725E2B13217E00F16FA8 /* CellButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CellButton.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -126,6 +128,7 @@
 				F60B9D732B0C9D740036AA1B /* AbilityButton.swift */,
 				F60B9D752B0CA85A0036AA1B /* NumberButton.swift */,
 				F60B9D852B0DEAED0036AA1B /* InformationView.swift */,
+				F632725E2B13217E00F16FA8 /* CellButton.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -224,6 +227,7 @@
 				F60B9D802B0DD2800036AA1B /* SudokuBoardDTO.swift in Sources */,
 				F60B9D722B0BA0520036AA1B /* UIBarButtonItem.swift in Sources */,
 				F60B9D842B0DD3030036AA1B /* GameDifficulty.swift in Sources */,
+				F632725F2B13217E00F16FA8 /* CellButton.swift in Sources */,
 				F60B9D762B0CA85A0036AA1B /* NumberButton.swift in Sources */,
 				F60B9D862B0DEAED0036AA1B /* InformationView.swift in Sources */,
 				F60B9D8C2B0F19930036AA1B /* Timer.swift in Sources */,

--- a/Sudoku/Sudoku.xcodeproj/project.pbxproj
+++ b/Sudoku/Sudoku.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		F60BB9592B0321D6005137FE /* TimeInterval.swift in Sources */ = {isa = PBXBuildFile; fileRef = F60BB9582B0321D6005137FE /* TimeInterval.swift */; };
 		F632725F2B13217E00F16FA8 /* CellButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = F632725E2B13217E00F16FA8 /* CellButton.swift */; };
 		F63272612B1429DB00F16FA8 /* SectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F63272602B1429DB00F16FA8 /* SectionView.swift */; };
+		F63272642B143B4000F16FA8 /* BoardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F63272632B143B4000F16FA8 /* BoardView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -56,6 +57,7 @@
 		F60BB9582B0321D6005137FE /* TimeInterval.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeInterval.swift; sourceTree = "<group>"; };
 		F632725E2B13217E00F16FA8 /* CellButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CellButton.swift; sourceTree = "<group>"; };
 		F63272602B1429DB00F16FA8 /* SectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SectionView.swift; sourceTree = "<group>"; };
+		F63272632B143B4000F16FA8 /* BoardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -132,6 +134,7 @@
 				F60B9D852B0DEAED0036AA1B /* InformationView.swift */,
 				F632725E2B13217E00F16FA8 /* CellButton.swift */,
 				F63272602B1429DB00F16FA8 /* SectionView.swift */,
+				F63272632B143B4000F16FA8 /* BoardView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -217,6 +220,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				F63272642B143B4000F16FA8 /* BoardView.swift in Sources */,
 				F60B9D702B0B04CC0036AA1B /* GameViewController.swift in Sources */,
 				F60B9D792B0DD1EB0036AA1B /* Networking.swift in Sources */,
 				F60BB9452B031BD9005137FE /* HomeViewController.swift in Sources */,

--- a/Sudoku/Sudoku/GameViewController.swift
+++ b/Sudoku/Sudoku/GameViewController.swift
@@ -17,6 +17,8 @@ class GameViewController: UIViewController {
         return stackView
     }()
 
+    private let boardView = BoardView()
+
     private let abilityStackView = {
         let stackView = UIStackView()
         stackView.distribution = .equalCentering
@@ -54,6 +56,8 @@ class GameViewController: UIViewController {
         informationStackView.addArrangedSubview(mistakeView)
         informationStackView.addArrangedSubview(timerView)
 
+
+
         AbilityButton.Ability.allCases.forEach { ability in
             let abilityButton = AbilityButton(of: ability)
             abilityStackView.addArrangedSubview(abilityButton)
@@ -79,10 +83,12 @@ class GameViewController: UIViewController {
 
     private func setLayout() {
         view.addSubview(informationStackView)
+        view.addSubview(boardView)
         view.addSubview(abilityStackView)
         view.addSubview(numberStackView)
 
         informationStackView.translatesAutoresizingMaskIntoConstraints = false
+        boardView.translatesAutoresizingMaskIntoConstraints = false
         abilityStackView.translatesAutoresizingMaskIntoConstraints = false
         numberStackView.translatesAutoresizingMaskIntoConstraints = false
 
@@ -91,12 +97,17 @@ class GameViewController: UIViewController {
             informationStackView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 30),
             informationStackView.centerXAnchor.constraint(equalTo: view.centerXAnchor),
 
+            boardView.widthAnchor.constraint(equalTo: view.widthAnchor, constant: -10),
+            boardView.heightAnchor.constraint(equalTo: boardView.widthAnchor),
+            boardView.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            boardView.centerYAnchor.constraint(equalTo: view.centerYAnchor, constant: -20),
+
             abilityStackView.widthAnchor.constraint(equalTo: view.widthAnchor, multiplier: 0.8),
-            abilityStackView.bottomAnchor.constraint(equalTo: numberStackView.topAnchor, constant: -30),
+            abilityStackView.topAnchor.constraint(equalTo: boardView.bottomAnchor, constant: 30),
             abilityStackView.centerXAnchor.constraint(equalTo: view.centerXAnchor),
 
             numberStackView.widthAnchor.constraint(equalTo: view.widthAnchor, multiplier: 0.9),
-            numberStackView.bottomAnchor.constraint(equalTo: view.bottomAnchor, constant: -30),
+            numberStackView.topAnchor.constraint(equalTo: abilityStackView.bottomAnchor, constant: 30),
             numberStackView.centerXAnchor.constraint(equalTo: view.centerXAnchor)
         ])
     }

--- a/Sudoku/Sudoku/GameViewController.swift
+++ b/Sudoku/Sudoku/GameViewController.swift
@@ -56,7 +56,10 @@ class GameViewController: UIViewController {
         informationStackView.addArrangedSubview(mistakeView)
         informationStackView.addArrangedSubview(timerView)
 
-
+        // MARK: - Board Test
+        boardView.sections.forEach { sectionView in
+            sectionView.delegate = self
+        }
 
         AbilityButton.Ability.allCases.forEach { ability in
             let abilityButton = AbilityButton(of: ability)
@@ -133,5 +136,11 @@ class GameViewController: UIViewController {
     @objc func runTime() {
         time += 1
         timerView.updateContent(by: .timer(content: time))
+    }
+}
+
+extension GameViewController: SectionViewDelegate {
+    func cellButtonTapped(_ button: CellButton) {
+        print(button.indexPath)
     }
 }

--- a/Sudoku/Sudoku/GameViewController.swift
+++ b/Sudoku/Sudoku/GameViewController.swift
@@ -35,6 +35,7 @@ class GameViewController: UIViewController {
     private let mistakeView = InformationView()
     private let timerView = InformationView()
 
+    var cursor: IndexPath?
     var timer: Timer?
     var time = 0
 
@@ -141,6 +142,26 @@ class GameViewController: UIViewController {
 
 extension GameViewController: SectionViewDelegate {
     func cellButtonTapped(_ button: CellButton) {
-        print(button.indexPath)
+        cursor = button.indexPath
+
+        guard let cursor else {
+            return
+        }
+
+        let row = boardView.row(associated: cursor)
+        let column = boardView.column(associated: cursor)
+        let section = boardView.section(associated: cursor)
+
+        row.forEach {
+            $0.paintedBackground(according: .associatedCursor)
+        }
+        column.forEach {
+            $0.paintedBackground(according: .associatedCursor)
+        }
+        section.forEach {
+            $0.paintedBackground(according: .associatedCursor)
+        }
+
+        button.paintedBackground(according: .selected)
     }
 }

--- a/Sudoku/Sudoku/GameViewController.swift
+++ b/Sudoku/Sudoku/GameViewController.swift
@@ -144,24 +144,6 @@ extension GameViewController: SectionViewDelegate {
     func cellButtonTapped(_ button: CellButton) {
         cursor = button.indexPath
 
-        guard let cursor else {
-            return
-        }
-
-        let row = boardView.row(associated: cursor)
-        let column = boardView.column(associated: cursor)
-        let section = boardView.section(associated: cursor)
-
-        row.forEach {
-            $0.paintedBackground(according: .associatedCursor)
-        }
-        column.forEach {
-            $0.paintedBackground(according: .associatedCursor)
-        }
-        section.forEach {
-            $0.paintedBackground(according: .associatedCursor)
-        }
-
-        button.paintedBackground(according: .selected)
+        boardView.paint(associated: button)
     }
 }

--- a/Sudoku/Sudoku/View/AbilityButton.swift
+++ b/Sudoku/Sudoku/View/AbilityButton.swift
@@ -116,11 +116,11 @@ extension AbilityButton {
         var description: String {
             switch self {
             case .undo:
-                return "undo"
+                return "실행 취소"
             case .erase:
-                return "erase"
+                return "지우기"
             case .memo:
-                return "memo"
+                return "메모"
             }
         }
 

--- a/Sudoku/Sudoku/View/BoardView.swift
+++ b/Sudoku/Sudoku/View/BoardView.swift
@@ -50,15 +50,47 @@ class BoardView: UIView {
 }
 
 extension BoardView {
-    func row(associated indexPath: IndexPath) -> [CellButton] {
+    func paint(associated button: CellButton) {
+        paintedReset()
+
+        let buttonsAssociatedCursor = buttons(associated: button)
+        buttonsAssociatedCursor.forEach { $0.paintedBackground(according: .associatedCursor) }
+
+        let numbers = numbers(associated: button)
+        numbers.forEach { $0.paintedBackground(according: .associatedNumber) }
+
+        let mistakeButtons = buttonsAssociatedCursor.filter { button.number != nil && $0.number == button.number }
+        mistakeButtons.forEach { $0.paintedBackground(according: .mistake) }
+
+        if !mistakeButtons.isEmpty {
+            button.paintedTextColor(according: .mistake)
+        }
+
+        button.paintedBackground(according: .selected)
+    }
+
+    func paintedReset() {
+        sections
+            .flatMap { $0.buttons }
+            .forEach { $0.paintedBackground(according: .normal) }
+    }
+
+    private func buttons(associated button: CellButton) -> [CellButton] {
+        let row = row(associated: button.indexPath)
+        let column = column(associated: button.indexPath)
+        let section = section(associated: button.indexPath)
+        return row + column + section
+    }
+
+    private func row(associated indexPath: IndexPath) -> [CellButton] {
         let sectionViews = sections.filter { $0.section / 3 == indexPath.section / 3 }
 
         return sectionViews
-            .flatMap { $0.buttons }
+            .flatMap {$0.buttons }
             .filter { $0.indexPath != indexPath && $0.indexPath.item / 3 == indexPath.item / 3 }
     }
 
-    func column(associated indexPath: IndexPath) -> [CellButton] {
+    private func column(associated indexPath: IndexPath) -> [CellButton] {
         let sectionViews = sections.filter { $0.section % 3 == indexPath.section % 3 }
 
         return sectionViews
@@ -66,9 +98,15 @@ extension BoardView {
             .filter { $0.indexPath != indexPath && $0.indexPath.item % 3 == indexPath.item % 3 }
     }
 
-    func section(associated indexPath: IndexPath) -> [CellButton] {
+    private func section(associated indexPath: IndexPath) -> [CellButton] {
         let buttons = sections[indexPath.section].buttons
 
         return buttons.filter { $0.indexPath != indexPath }
+    }
+
+    private func numbers(associated button: CellButton) -> [CellButton] {
+        return sections
+            .flatMap { $0.buttons }
+            .filter { button.number != nil && $0.indexPath != button.indexPath && $0.number == button.number }
     }
 }

--- a/Sudoku/Sudoku/View/BoardView.swift
+++ b/Sudoku/Sudoku/View/BoardView.swift
@@ -48,3 +48,27 @@ class BoardView: UIView {
         }
     }
 }
+
+extension BoardView {
+    func row(associated indexPath: IndexPath) -> [CellButton] {
+        let sectionViews = sections.filter { $0.section / 3 == indexPath.section / 3 }
+
+        return sectionViews
+            .flatMap { $0.buttons }
+            .filter { $0.indexPath != indexPath && $0.indexPath.item / 3 == indexPath.item / 3 }
+    }
+
+    func column(associated indexPath: IndexPath) -> [CellButton] {
+        let sectionViews = sections.filter { $0.section % 3 == indexPath.section % 3 }
+
+        return sectionViews
+            .flatMap { $0.buttons }
+            .filter { $0.indexPath != indexPath && $0.indexPath.item % 3 == indexPath.item % 3 }
+    }
+
+    func section(associated indexPath: IndexPath) -> [CellButton] {
+        let buttons = sections[indexPath.section].buttons
+
+        return buttons.filter { $0.indexPath != indexPath }
+    }
+}

--- a/Sudoku/Sudoku/View/BoardView.swift
+++ b/Sudoku/Sudoku/View/BoardView.swift
@@ -1,0 +1,50 @@
+//
+//  BoardView.swift
+//  Sudoku
+//
+//  Created by 박재우 on 11/27/23.
+//
+
+import UIKit
+
+class BoardView: UIView {
+    private(set) var sections = [SectionView]()
+
+    init() {
+        super.init(frame: .zero)
+
+        sections = stride(from: 0, to: 9, by: 1).map { section in
+            SectionView(section: section)
+        }
+
+        setUI()
+        setLayout()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    private func setUI() {
+        layer.borderColor = UIColor.systemGray.cgColor
+        layer.borderWidth = 2
+    }
+
+    private func setLayout() {
+        for (index, sectionView) in sections.enumerated() {
+            addSubview(sectionView)
+
+            sectionView.translatesAutoresizingMaskIntoConstraints = false
+
+            let topAnchor = index / 3 == 0 ? topAnchor : sections[index - 3].bottomAnchor
+            let leadingAnchor = index % 3 == 0 ? leadingAnchor : sections[index % 3 - 1].trailingAnchor
+
+            NSLayoutConstraint.activate([
+                sectionView.widthAnchor.constraint(equalTo: widthAnchor, multiplier: 1 / 3),
+                sectionView.heightAnchor.constraint(equalTo: heightAnchor, multiplier: 1 / 3),
+                sectionView.topAnchor.constraint(equalTo: topAnchor),
+                sectionView.leadingAnchor.constraint(equalTo: leadingAnchor)
+            ])
+        }
+    }
+}

--- a/Sudoku/Sudoku/View/CellButton.swift
+++ b/Sudoku/Sudoku/View/CellButton.swift
@@ -114,4 +114,36 @@ extension CellButton {
 
         memoLabels[number - 1].isHidden.toggle()
     }
+
+    func paintedBackground(according state: State) {
+        switch state {
+        case .selected, .associatedNumber:
+            backgroundColor = .brightMainColor1
+        case .associatedCursor:
+            backgroundColor = .brightMainColor2
+        case .mistake:
+            backgroundColor = .systemRed.withAlphaComponent(0.3)
+        case .normal:
+            backgroundColor = .clear
+        }
+    }
+
+    func paintedTextColor(according state: State) {
+        switch state {
+        case .mistake:
+            numberLabel.textColor = .red
+        default:
+            numberLabel.textColor = .darkMainColor1
+        }
+    }
+}
+
+extension CellButton {
+    enum State {
+        case associatedNumber
+        case associatedCursor
+        case selected
+        case mistake
+        case normal
+    }
 }

--- a/Sudoku/Sudoku/View/CellButton.swift
+++ b/Sudoku/Sudoku/View/CellButton.swift
@@ -8,6 +8,7 @@
 import UIKit
 
 class CellButton: UIButton {
+    let indexPath: IndexPath
     private let numberLabel: UILabel = {
         let label = UILabel()
         label.textAlignment = .center
@@ -21,7 +22,9 @@ class CellButton: UIButton {
         }
     }
 
-    init() {
+    init(item: Int, section: Int) {
+        indexPath = IndexPath(item: item, section: section)
+
         super.init(frame: .zero)
 
         setUI()

--- a/Sudoku/Sudoku/View/CellButton.swift
+++ b/Sudoku/Sudoku/View/CellButton.swift
@@ -87,7 +87,7 @@ class CellButton: UIButton {
 
 extension CellButton {
     func number(to number: Int) {
-        resetMemoNumbers()
+        resetMemo()
 
         self.number = number
     }
@@ -95,10 +95,10 @@ extension CellButton {
     func reset() {
         number = nil
 
-        resetMemoNumbers()
+        resetMemo()
     }
 
-    func resetMemoNumbers() {
+    func resetMemo() {
         memoLabels.forEach {
             $0.isHidden = true
         }

--- a/Sudoku/Sudoku/View/CellButton.swift
+++ b/Sudoku/Sudoku/View/CellButton.swift
@@ -1,0 +1,114 @@
+//
+//  CellButton.swift
+//  Sudoku
+//
+//  Created by 박재우 on 11/26/23.
+//
+
+import UIKit
+
+class CellButton: UIButton {
+    private let numberLabel: UILabel = {
+        let label = UILabel()
+        label.textAlignment = .center
+        label.font = UIFont.systemFont(ofSize: 33, weight: .semibold)
+        return label
+    }()
+    private var memoLabels = [UILabel]()
+    private(set) var number: Int? {
+        didSet {
+            numberLabel.text = convert(of: number)
+        }
+    }
+
+    init() {
+        super.init(frame: .zero)
+
+        setUI()
+        setupLayout()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    private func setUI() {
+        layer.borderWidth = 0.5
+        layer.borderColor = UIColor.systemGray5.cgColor
+
+        for index in stride(from: 0, to: 9, by: 1) {
+            let label = UILabel()
+            label.text = "\(index + 1)"
+            label.textAlignment = .center
+            label.font = UIFont.systemFont(ofSize: 12, weight: .light)
+            label.isHidden = true
+
+            memoLabels.append(label)
+        }
+    }
+
+    private func setupLayout() {
+        addSubview(numberLabel)
+
+        numberLabel.translatesAutoresizingMaskIntoConstraints = false
+
+        NSLayoutConstraint.activate([
+            numberLabel.topAnchor.constraint(equalTo: topAnchor),
+            numberLabel.leadingAnchor.constraint(equalTo: leadingAnchor),
+            numberLabel.trailingAnchor.constraint(equalTo: trailingAnchor),
+            numberLabel.bottomAnchor.constraint(equalTo: bottomAnchor),
+        ])
+
+        for (index, memoLabel) in memoLabels.enumerated() {
+            addSubview(memoLabel)
+
+            memoLabel.translatesAutoresizingMaskIntoConstraints = false
+
+            let topAnchor = index / 3 == 0 ? topAnchor : memoLabels[index - 3].bottomAnchor
+            let leadingAnchor = index % 3 == 0 ? leadingAnchor : memoLabels[index % 3 - 1].trailingAnchor
+
+            NSLayoutConstraint.activate([
+                memoLabel.widthAnchor.constraint(equalTo: widthAnchor, multiplier: 1 / 3),
+                memoLabel.heightAnchor.constraint(equalTo: heightAnchor, multiplier: 1 / 3),
+                memoLabel.topAnchor.constraint(equalTo: topAnchor),
+                memoLabel.leadingAnchor.constraint(equalTo: leadingAnchor)
+            ])
+        }
+    }
+
+    private func convert(of number: Int?) -> String {
+        guard let number else {
+            return ""
+        }
+
+        return number.description
+    }
+}
+
+extension CellButton {
+    func number(to number: Int) {
+        resetMemoNumbers()
+
+        self.number = number
+    }
+
+    func reset() {
+        number = nil
+
+        resetMemoNumbers()
+    }
+
+    func resetMemoNumbers() {
+        memoLabels.forEach {
+            $0.isHidden = true
+        }
+    }
+
+    func memo(to number: Int) {
+        if self.number != nil {
+            self.number = nil
+        }
+
+        memoLabels[number - 1].isHidden.toggle()
+    }
+}

--- a/Sudoku/Sudoku/View/CellButton.swift
+++ b/Sudoku/Sudoku/View/CellButton.swift
@@ -124,7 +124,7 @@ extension CellButton {
         case .mistake:
             backgroundColor = .systemRed.withAlphaComponent(0.3)
         case .normal:
-            backgroundColor = .clear
+            backgroundColor = nil
         }
     }
 

--- a/Sudoku/Sudoku/View/GameButton.swift
+++ b/Sudoku/Sudoku/View/GameButton.swift
@@ -45,7 +45,7 @@ extension GameButton {
         var backgroundColor: UIColor {
             switch self {
             case .new:
-                return .white
+                return .systemBackground
             case .continue:
                 return .mainBlue
             }

--- a/Sudoku/Sudoku/View/SectionView.swift
+++ b/Sudoku/Sudoku/View/SectionView.swift
@@ -1,0 +1,64 @@
+//
+//  SectionView.swift
+//  Sudoku
+//
+//  Created by 박재우 on 11/27/23.
+//
+
+import UIKit
+
+protocol SectionViewDelegate: AnyObject {
+    func cellButtonTapped(_ button: CellButton)
+}
+
+class SectionView: UIView {
+    weak var delegate: SectionViewDelegate?
+    private let section: Int
+    private var buttons = [CellButton]()
+
+    init(section: Int) {
+        self.section = section
+
+        super.init(frame: .zero)
+
+        stride(from: 0, to: 9, by: 1).forEach { item in
+            let button = CellButton(item: item, section: section)
+            button.addTarget(self, action: #selector(cellButtonTapped), for: .touchDown)
+            buttons.append(button)
+        }
+
+        setUI()
+        setLayout()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    private func setUI() {
+        layer.borderColor = UIColor.systemGray3.cgColor
+        layer.borderWidth = 1
+    }
+
+    private func setLayout() {
+        for (index, button) in buttons.enumerated() {
+            addSubview(button)
+
+            button.translatesAutoresizingMaskIntoConstraints = false
+
+            let topAnchor = index / 3 == 0 ? topAnchor : buttons[index - 3].bottomAnchor
+            let leadingAnchor = index % 3 == 0 ? leadingAnchor : buttons[index % 3 - 1].trailingAnchor
+
+            NSLayoutConstraint.activate([
+                button.widthAnchor.constraint(equalTo: widthAnchor, multiplier: 1 / 3),
+                button.heightAnchor.constraint(equalTo: heightAnchor, multiplier: 1 / 3),
+                button.topAnchor.constraint(equalTo: topAnchor),
+                button.leadingAnchor.constraint(equalTo: leadingAnchor)
+            ])
+        }
+    }
+
+    @objc private func cellButtonTapped(_ sender: CellButton) {
+        delegate?.cellButtonTapped(sender)
+    }
+}

--- a/Sudoku/Sudoku/View/SectionView.swift
+++ b/Sudoku/Sudoku/View/SectionView.swift
@@ -36,7 +36,7 @@ class SectionView: UIView {
     }
 
     private func setUI() {
-        layer.borderColor = UIColor.systemGray3.cgColor
+        layer.borderColor = UIColor.systemGray.cgColor
         layer.borderWidth = 1
     }
 

--- a/Sudoku/Sudoku/View/SectionView.swift
+++ b/Sudoku/Sudoku/View/SectionView.swift
@@ -13,8 +13,8 @@ protocol SectionViewDelegate: AnyObject {
 
 class SectionView: UIView {
     weak var delegate: SectionViewDelegate?
-    private let section: Int
-    private var buttons = [CellButton]()
+    private(set) var section: Int
+    private(set) var buttons = [CellButton]()
 
     init(section: Int) {
         self.section = section


### PR DESCRIPTION
# BoardView
- 3 * 3 형태의 SectionView와 3 *3 형태의 CellButtons으로 이뤄진 BoardView
- AutoLayout 설정
- 버튼을 탭하는 이벤트할 때마다 메서드 동작
  - 배경 색 변경
  - mistake가 발생하는 경우에는 텍스트 색 변경
## CellButton
- number 및 memo 입력받을 수 있도록 메서드 추가
- 배경 및 텍스트 색 변경하도록 메서드 추가
## SectionView
- GameViewController에서 CellButton action 추가하기 위해 delegate 구현

## 추가된 코드

### AutoLayout 설정
3 * 3의 형태를 autolayout으로 구현하기 위해 view를 배열로 저장하며 index를 이용하여 설정
```swift
let topAnchor = index / 3 == 0 ? topAnchor : buttons[index - 3].bottomAnchor
let leadingAnchor = index % 3 == 0 ? leadingAnchor : buttons[index % 3 - 1].trailingAnchor

NSLayoutConstraint.activate([
    button.widthAnchor.constraint(equalTo: widthAnchor, multiplier: 1 / 3),
    button.heightAnchor.constraint(equalTo: heightAnchor, multiplier: 1 / 3),
    button.topAnchor.constraint(equalTo: topAnchor),
    button.leadingAnchor.constraint(equalTo: leadingAnchor)
])
```

### delegate 추가
GameViewController에서는 각 CellButton의 action을 추가하기 위해`BoardView.sectionView(section: 3).cellButton(item: 4).addTarget` 와 같은 코드를 반복문으로 구현을 피하기 위해 아래와 같은 코드로 구현
```swift
protocol SectionViewDelegate: AnyObject {
    func cellButtonTapped(_ button: CellButton)
}

class SectionView: UIView {
    weak var delegate: SectionViewDelegate?

    init() {
        stride(from: 0, to: 9, by: 1).forEach { item in
            let button = CellButton(item: item, section: section)
            button.addTarget(self, action: #selector(cellButtonTapped), for: .touchDown)
        }
    }

    @objc private func cellButtonTapped(_ sender: CellButton) {
        delegate?.cellButtonTapped(sender)
    }
}
```

### CellButton의 이벤트에 따른 UI 변경
Cursor를 통해 선택된 CellButton을 기억
Cursor와 겹치는 행, 열 그리고 섹션의 배경색 변경
Cursor에 번호가 존재한다면 동일한 번호들의 배경색 변경을 위한 메서드 추가
(테스트를 위해서는 API로 데이터 연결 필요)
<img src=https://github.com/ohdair/Sudoku/assets/79438622/40812bbb-b302-489a-a4aa-b197471a94bb width=400>
